### PR TITLE
Fix notification uri context

### DIFF
--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -10,21 +10,6 @@ import * as messagesUri from "./messages-uri";
 import * as microsoftAccount from "./providers/microsoft-account";
 import { ApiProfile } from "./types/api-profile";
 
-const notificationEnd: any = {
-  uri: undefined,
-};
-
-export function getNotificationUri() {
-  return notificationEnd;
-}
-export function setNotificationUri(uri: string) {
-  notificationEnd.uri = uri;
-  return notificationEnd.uri;
-}
-export function resetNotificationUri() {
-  notificationEnd.uri = undefined;
-}
-
 interface IoOptions {
   io: io.HttpIo;
   cookies: toughCookie.Store;
@@ -90,15 +75,6 @@ export async function login(options: LoginOptions): Promise<ApiContext> {
   if (options.verbose) {
     console.log("Subscribed to resources");
   }
-
-  const updatedRegistrationInfo: RegistrationInfo = await updateRegistrationInfo(
-    ioOptions.io,
-    ioOptions.cookies,
-    skypeToken,
-    registrationToken,
-    options.proxy,
-  );
-  notificationEnd.uri = updatedRegistrationInfo.subscriptions[0].longPollUrl;
 
   await createPresenceDocs(ioOptions, registrationToken, options.proxy);
   if (options.verbose) {

--- a/src/lib/messages-uri.ts
+++ b/src/lib/messages-uri.ts
@@ -5,7 +5,9 @@ import url from "url";
 export const DEFAULT_USER: string = "ME";
 export const DEFAULT_ENDPOINT: string = "SELF";
 
-import { getNotificationUri, resetNotificationUri } from "./login";
+import { updateRegistrationInfo } from "./helpers/register-endpoint";
+import { RegistrationInfo } from "./interfaces/api/context";
+import * as httpIo from "./interfaces/http-io";
 
 const CONVERSATION_PATTERN: RegExp = /^\/v1\/users\/([^/]+)\/conversations\/([^/]+)$/;
 const CONTACT_PATTERN: RegExp = /^\/v1\/users\/([^/]+)\/contacts\/([^/]+)$/;
@@ -212,15 +214,19 @@ export function poll(host: string, userId: string = DEFAULT_USER,
  * Uri example: https://eus.notifications.skype.com/users/8:{skypeId}
  * /endpoints/{endpointId}/events/poll?cursor=1563307584&sca=2&pageSize=20
  *
+ * @param io
  * @param apiContext
- * @return Formated notifications URI
+ * @return  notifications URI
  */
-export function notifications(apiContext: any): string {
-  const notificationEndpoint: string =
-    getNotificationUri().uri;
-
-  // removeNotificationEndpoint(apiContext.registrationToken.endpointId);
-  return notificationEndpoint;
+export async function notifications(io: httpIo.HttpIo, apiContext: any): Promise<string> {
+  const updatedRegistrationInfo: RegistrationInfo =  await updateRegistrationInfo(
+    io,
+    apiContext.cookies,
+    apiContext.skypeToken,
+    apiContext.registrationToken,
+    apiContext.proxy,
+  );
+  return updatedRegistrationInfo.subscriptions[0].longPollUrl;
 }
 
 /**


### PR DESCRIPTION
Sometimes when having 2 users in parallel the notification uri got mixed up and could cause one user to attempt to request notifications using the second user's uri, ofc this resulted in memory leak to the the high amount of errors.