### PR TITLE
Update registration token when new one is received

### DIFF
--- a/src/lib/helpers/register-endpoint.ts
+++ b/src/lib/helpers/register-endpoint.ts
@@ -186,7 +186,7 @@ export async function updateRegistrationInfo(
  * @param header String value of the `Set-Registration` header.
  * @return Parsed registration token
  */
-function readSetRegistrationTokenHeader(hostname: string, header: string): RegistrationToken {
+export function readSetRegistrationTokenHeader(hostname: string, header: string): RegistrationToken {
   const parsedHeader: Map<string, string> = utils.parseHeaderParams(header);
   const expiresString: string | undefined = parsedHeader.get("expires");
   const registrationTokenValue: string | undefined = parsedHeader.get("registrationToken");

--- a/src/lib/providers/microsoft-account.ts
+++ b/src/lib/providers/microsoft-account.ts
@@ -380,7 +380,8 @@ export function scrapLiveToken(html: string): string {
 
   const tokenValue: string | undefined = tokenNode.val();
   if (tokenValue === undefined || tokenValue === "") {
-    if (html.indexOf("sErrTxt:'Your account or password is incorrect.") >= 0) {
+    if (html.indexOf("sErrTxt:'Your account or password is incorrect.") >= 0
+      && html.indexOf("GoogleRedirectUrl") < 0) {
       throw WrongCredentialsError.create();
       /* tslint:disable-next-line:max-line-length */
     } else if (html.indexOf("sErrTxt:\"You\\'ve tried to sign in too many times with an incorrect account or password.\"") >= 0) {


### PR DESCRIPTION
We may receive a new registration token, as a header, on the message/notification poll endpoints, with the new logic the token should now be correctly updated.