### PR TITLE
update search contact api to work with phone numbers and emails

### DIFF
--- a/src/lib/api/search-directory.ts
+++ b/src/lib/api/search-directory.ts
@@ -14,10 +14,20 @@ export async function searchSkypeDirectory(io: io.HttpIo,
     you cannot get data for ${JSON.stringify(userId)}`);
   }
   try {
+    const uriBase: string = "https://skypegraph.skype.com/v2.0/search?";
+
+    const sessionId: string  =  apiContext.registrationToken.endpointId
+                                      .replace("{", "").replace("}", "");
+
+    const uri: string  = `${uriBase}searchString=${encodeURIComponent(userId)
+                          }&requestId=${Math.round((new Date()).getTime())
+                          }0&sessionId=${sessionId}`;
+
+    console.log(uri);
     // get X-ECS-ETag from response headers and use it
     const requestOptions: io.GetOptions = {
-      uri: `https://skypegraph.skype.com/v2.0/search?searchString=${userId}
-    &requestId=${Math.round((new Date()).getTime())}`,
+      // tslint:disable-next-line:prefer-template
+      uri,
       cookies: apiContext.cookies,
       proxy: apiContext.proxy,
       headers: {
@@ -42,6 +52,7 @@ export async function searchSkypeDirectory(io: io.HttpIo,
     }
 
     const body: any = JSON.parse(res.body);
+    console.log(body);
     const results: any = body.results;
     const searchResults: any[] = [];
 

--- a/src/lib/interfaces/api/contact.ts
+++ b/src/lib/interfaces/api/contact.ts
@@ -9,6 +9,7 @@ export interface Phone {
 export interface Contact {
   // TODO: Use MriKey
   id: FullId;
+  workloads: "skype" | string | null; // probably enum
   avatarUrl: string | null;
   phones: Phone[];
   emails?: String[];

--- a/src/lib/interfaces/native-api/contact.ts
+++ b/src/lib/interfaces/native-api/contact.ts
@@ -14,6 +14,7 @@ export interface SearchContact {
   country: string;
   city: string;
   avatarUrl: string;
+  workloads: string | null;
   displayname: string;
   username: string;
   mood: string;
@@ -24,6 +25,7 @@ export interface SearchContact {
 export interface Contact {
   id: string; // username
   person_id: string; // [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+  workloads: "skype" | string | null; // probably enum
   type: "skype" | "agent" | string; // enum ?
   display_name: string;
   authorized?: boolean; // accepted contact request ?

--- a/src/lib/types/contact.ts
+++ b/src/lib/types/contact.ts
@@ -19,6 +19,7 @@ export interface Contact {
    * the user.
    */
   personId: MriKey;
+  workloads: "skype" | string | null; // probably enum
   /**
    * MRI key of this contact, this serves as the unique id for this contact.
    */
@@ -59,6 +60,7 @@ export interface Contact {
 export const $Contact: DocumentType<Contact> = new DocumentType<Contact>({
   properties: {
     personId: {type: $MriKey},
+    workloads: {type: new Ucs2StringType({maxLength: Infinity}), optional: true},
     mri: {type: $MriKey},
     displayName: {type: $DisplayName},
     displayNameSource: {type: $DisplayNameSource},

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -71,13 +71,13 @@ function define(...args: any[]) {
 
 function searchContactToPerson(native: NativeSearchContact): Contact {
   let avatarUrl: string | null;
-
   if (typeof native.avatarUrl === "string") {
     avatarUrl = ensureHttps(native.avatarUrl);
     // TODO: ensure that the "cacheHeaders=1" queryString is there
   } else {
     avatarUrl = null;
   }
+  const workloads: string | null  = native.workloads;
   const displayName: string = sanitizeXml(native.displayname);
   const firstName: string | null = (native.firstname !== undefined) ? sanitizeXml(native.firstname) : null;
   const lastName: string | null = (native.lastname !== undefined) ? sanitizeXml(native.lastname) : null;
@@ -94,6 +94,7 @@ function searchContactToPerson(native: NativeSearchContact): Contact {
       typeName: mriTypeToTypeName(type),
       raw: `${typeKey}:${native.username}`,
     },
+    workloads,
     emails: native.emails,
     avatarUrl,
     phones: phoneNumbers,
@@ -170,6 +171,7 @@ function contactToPerson(native: NativeContact): Contact {
   } else {
     avatarUrl = null;
   }
+  const workloads: string | null  = native.workloads;
 
   const displayName: string = sanitizeXml(native.display_name);
   let firstName: string | null = null;
@@ -192,6 +194,7 @@ function contactToPerson(native: NativeContact): Contact {
       typeName: native.type,
       raw: `${typeKey}:${native.id}`,
     },
+    workloads,
     avatarUrl,
     phones: phoneNumbers,
     name: {


### PR DESCRIPTION
The search contact API was recently updated to work with full email addresses instead of only with the first part.
Added the new property to Contacts templates