### PR TITLE
Handle proxy error and added debug logs

### DIFF
--- a/src/lib/api/search-directory.ts
+++ b/src/lib/api/search-directory.ts
@@ -23,7 +23,6 @@ export async function searchSkypeDirectory(io: io.HttpIo,
                           }&requestId=${Math.round((new Date()).getTime())
                           }0&sessionId=${sessionId}`;
 
-    console.log(uri);
     // get X-ECS-ETag from response headers and use it
     const requestOptions: io.GetOptions = {
       // tslint:disable-next-line:prefer-template
@@ -52,7 +51,6 @@ export async function searchSkypeDirectory(io: io.HttpIo,
     }
 
     const body: any = JSON.parse(res.body);
-    console.log(body);
     const results: any = body.results;
     const searchResults: any[] = [];
 

--- a/src/lib/errors/proxy-error.ts
+++ b/src/lib/errors/proxy-error.ts
@@ -1,0 +1,27 @@
+import { Incident } from "incident";
+
+export namespace ProxyError {
+  export type Name = "ProxyError";
+  export const name: Name = "ProxyError";
+
+  export interface Data {
+    html: string;
+  }
+
+  export type Cause = undefined;
+}
+
+export type ProxyError = Incident<ProxyError.Data,
+  ProxyError.Name, ProxyError.Cause>;
+
+export namespace ProxyError {
+  export type Type = ProxyError;
+
+  export function format({html}: Data) {
+    return "ProxyError" + ` HTML page: ${JSON.stringify(html)}`;
+  }
+
+  export function create(html: string): ProxyError {
+    return Incident(name, {html}, format);
+  }
+}


### PR DESCRIPTION
Handle proxy error and added debug logs to gather additional info for `UnexpectedResult: { body: { status: { code: 40100, text: 'Authentication failed' } } }`